### PR TITLE
Pacmom Fix

### DIFF
--- a/Assets/Scripts/Runtime/CH1/Pacmom/Dialogues/InGameDialogue.cs
+++ b/Assets/Scripts/Runtime/CH1/Pacmom/Dialogues/InGameDialogue.cs
@@ -110,7 +110,9 @@ namespace Runtime.CH1.Pacmom
             _bubbleA.SetActive(true);
 
             CancelInvoke(nameof(HideBubbleA));
-            Invoke(nameof(HideBubbleA), 3f);
+
+            if (!GameController.IsGameOver)
+                Invoke(nameof(HideBubbleA), 3f);
         }
 
         private void ShowBubbleB()
@@ -118,7 +120,9 @@ namespace Runtime.CH1.Pacmom
             _bubbleB.SetActive(true);
 
             CancelInvoke(nameof(HideBubbleB));
-            Invoke(nameof(HideBubbleB), 3f);
+
+            if (!GameController.IsGameOver)
+                Invoke(nameof(HideBubbleB), 3f);
         }
 
         public void StopDialogue()

--- a/Assets/Scripts/Runtime/CH1/Pacmom/PMData.cs
+++ b/Assets/Scripts/Runtime/CH1/Pacmom/PMData.cs
@@ -176,7 +176,8 @@ namespace Runtime.CH1.Pacmom
 
         private void ChooseAWinner()
         {
-            Managers.Sound.StopEffect(); // BGM 사용 시 StopAllSound
+            Managers.Sound.StopEffect();
+            _gameController.DialogueStop();
 
             if (_rapleyScore > _pacmomScore)
                 _ending.RapleyWin();

--- a/Assets/Scripts/Runtime/CH1/Pacmom/PMEnding.cs
+++ b/Assets/Scripts/Runtime/CH1/Pacmom/PMEnding.cs
@@ -34,7 +34,7 @@ namespace Runtime.CH1.Pacmom
 
             Debug.Log("팩맘 승리");
             Time.timeScale = 0;
-            StartCoroutine(nameof(ToMain));
+            // StartCoroutine(nameof(ToMain));
         }
 
         private void GamePlayed()

--- a/Assets/Scripts/Runtime/CH1/Pacmom/PMGameController.cs
+++ b/Assets/Scripts/Runtime/CH1/Pacmom/PMGameController.cs
@@ -41,6 +41,7 @@ namespace Runtime.CH1.Pacmom
         #region Awake
         private void Awake()
         {
+            Managers.Data.SaveGame();
             AssignComponent();
             AssignController();
             SetSettingUI();

--- a/Assets/Scripts/Runtime/CH1/Pacmom/PMGameController.cs
+++ b/Assets/Scripts/Runtime/CH1/Pacmom/PMGameController.cs
@@ -280,9 +280,14 @@ namespace Runtime.CH1.Pacmom
 
         public void AfterPacmomEatenByDust()
         {
-            _dialogue.StopDialogue();
+            DialogueStop();
             SetCharacterMove(true);
             LoseLife();
+        }
+
+        public void DialogueStop()
+        {
+            _dialogue.StopDialogue();
         }
 
         public void LoseLife()

--- a/Assets/_CH1/_Pacmom/Scene/Pacmom.unity
+++ b/Assets/_CH1/_Pacmom/Scene/Pacmom.unity
@@ -1311,7 +1311,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &321128175
 RectTransform:
   m_ObjectHideFlags: 0

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -11,10 +11,10 @@ EditorBuildSettings:
   - enabled: 0
     path: Assets/_CH1/Scene/CH1.unity
     guid: b114ef1e23b4e3f448ba9f32c6b7a629
-  - enabled: 0
+  - enabled: 1
     path: Assets/_CH1/_Pacmom/Scene/Pacmom.unity
     guid: 357a46f50fedfd946a8043ba4bff29d3
-  - enabled: 1
+  - enabled: 0
     path: Assets/_Main/_Title/Scene/Title.unity
     guid: 1b3a2d1c03ab698408b1c1529fa4130e
   m_configObjects:

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -138,6 +138,7 @@ PlayerSettings:
   bundleVersion: 0.1
   preloadedAssets:
   - {fileID: 11400000, guid: 040d2c0d275f8db46a1e1d7dda21d78b, type: 2}
+  - {fileID: 11400000, guid: ddc15bbc1419fef4cbf8bc7636cf3ba4, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
팩맘 빌드본 요청에 따라 빌드
해당 과정에서 커밋 조금

1. 원래 Main씬에서 TopDown씬 또는 Pacmom씬으로 이동 가능했으나, Main씬이 수정됨.
   따라서 Main 씬과 연결을 끊고 Pacmom만 뽑아서 빌드
2. 이전에 인게임 말풍선은 출력 후 3초 뒤에 꺼지게 설정되어 있음.
   하지만 수정 과정에서 GameOver 대사는 점수 계산이 끝날 때까지 표시하는 거 깜빡했던 듯..
   그래서 급하게 수정